### PR TITLE
support elixir 12.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Redis.Mixfile do
   def project do
     [ app: :redis,
       version: "0.0.1",
-      elixir: "~> 0.10.3-dev",
+      elixir: "~> 0.12.2",
       deps: deps ]
   end
 


### PR DESCRIPTION
elixir 12.2 just came out the other day and this library is compatible, yet the spec claims it's not.

this just updates it to support that.
